### PR TITLE
v2.0.1 - C_ClassColor only exists in Mainline from BFA on

### DIFF
--- a/Data/Options/Options.lua
+++ b/Data/Options/Options.lua
@@ -358,6 +358,18 @@ function WhoTaunted:CheckOptions()
 		WhoTaunted.options.args.Announcements.args.AnounceFailsOutput.disabled = true;
 	end
 
+    if (not tContains(WhoTaunted.OutputTypes, WhoTaunted.db.profile.AnounceTauntsOutput)) then
+        WhoTaunted.db.profile.AnounceTauntsOutput = WhoTaunted.OutputTypes.Self;
+    end
+
+    if (not tContains(WhoTaunted.OutputTypes, WhoTaunted.db.profile.AnounceAOETauntsOutput)) then
+        WhoTaunted.db.profile.AnounceAOETauntsOutput = WhoTaunted.OutputTypes.Self;
+    end
+
+    if (not tContains(WhoTaunted.OutputTypes, WhoTaunted.db.profile.AnounceFailsOutput)) then
+        WhoTaunted.db.profile.AnounceFailsOutput = WhoTaunted.OutputTypes.Self;
+    end
+
 	if (WhoTaunted.db.profile.Disabled == true) then
 		WhoTaunted.options.args.General.disabled = true;
 		WhoTaunted.options.args.Announcements.disabled = true;

--- a/WhoTaunted.lua
+++ b/WhoTaunted.lua
@@ -458,15 +458,11 @@ function WhoTaunted:PrintToChatWindow(message, ChatWindow)
 end
 
 function WhoTaunted:GetClassColor(Unit)
-	local classFile;
+	local _, classFilename, _ = UnitClass(Unit);
 	local ClassColor = "00FFFFFF";
 
-	if (Unit) then
-		_, classFile, _ = UnitClass(Unit);
-		if (classFile) then
-			local color = C_ClassColor.GetClassColor(classFile);
-			ClassColor = color:GenerateHexColor();
-		end
+	if (Unit) and (classFilename) then
+		_, _, _, ClassColor = GetClassColor(classFilename);
 	end
 
 	return ClassColor;

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,8 @@
+v2.0.1:
+- Fixed a bug where errors were thrown in Classic when a player taunts. Some code from Mainline WoW was not compatible in Classic.
+- Fixed some issues with the Chat Window Options.
+- Fixed a rare bug with the Taunt Output Options.
+
 v2.0:
 - 9.2.7 Compatibility.
 - Wrath Classic 3.4.0 Support and Compatibility.


### PR DESCRIPTION
C_ClassColor only exists in Mainline from BFA on. It does not exist in Wrath Classic. Switching to utilizing the GetClassColor Blizzard function. This fixes #8.