### PR TITLE
v2.0.5

### DIFF
--- a/WhoTaunted.lua
+++ b/WhoTaunted.lua
@@ -129,7 +129,7 @@ end
 
 function WhoTaunted:DisplayTaunt(Event, Name, ID, TargetGUID, Target, FailType, Time)
 	if (Event) and (Name) and (ID) and (Time) and (WhoTaunted:IsRecentTaunt(Name, ID, Time) == false) then
-		if (WhoTaunted.db.profile.Disabled == false) and (BgDisable == false) and (DisableInPvPZone == false) and (UnitIsPlayer(Name)) and ((UnitInParty("player")) or (UnitInRaid("player"))) and ((UnitInParty(Name)) or (UnitInRaid(Name))) then
+		if (WhoTaunted.db.profile.Disabled == false) and (BgDisable == false) and (DisableInPvPZone == false) and (UnitIsPlayer(Name)) and (((IsInGroup(LE_PARTY_CATEGORY_HOME)) or (IsInRaid(LE_PARTY_CATEGORY_HOME))) or ((IsInGroup(LE_PARTY_CATEGORY_INSTANCE)) or (IsInRaid(LE_PARTY_CATEGORY_INSTANCE)))) and ((UnitInParty(Name)) or (UnitInRaid(Name))) then
 			local OutputMessage = nil;
 			local IsTaunt, TauntType;
 			local OutputType;

--- a/WhoTaunted.toc
+++ b/WhoTaunted.toc
@@ -1,5 +1,5 @@
 ## Author: @project-author@
-## Interface: 100000
+## Interface: 100002
 ## Notes: Tracks player taunts and displays who they taunted, what ability they used to taunt, and if it failed in some way.
 ## OptionalDeps: Ace3
 ## SavedVariables: WhoTauntedDB

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,7 @@
+v2.0.5:
+- 10.0.2 compatibility.
+- Minor code change for Party and Raid detection.
+
 v2.0.4:
 - Fixed a localization issue which caused options for Output types to not function correctly (#15).
 - Added a new option which defaults the output to Self if any of the outputs are unavailable. For example, if you are not in a party or raid.


### PR DESCRIPTION
- Toc bump for 10.0.2.
- Switching from using UnitInParty and UnitInRaid to the IsInGroup and IsInRaid counterparts for the initial taunt detection.