### PR TITLE
Updated Wrath Taunts

### DIFF
--- a/Data/DB/TauntsList_Wrath.lua
+++ b/Data/DB/TauntsList_Wrath.lua
@@ -2,37 +2,86 @@ local WhoTaunted = WhoTaunted;
 
 WhoTaunted.TauntsList = {
 	SingleTarget = {
-		--Warrior
-		355, --Taunt
-		694, --Mocking Blow
+		-- Death Knight
+		49576, 			-- Death Grip
+		51399, 			-- Death Grip for Blood (49576 is now just the pull effect)
+		56222, 			-- Dark Command
 
-		--Death Knight
-		51399, --Death Grip for Blood (49576 is now just the pull effect)
-		56222, --Dark Command
+		-- Druid
+		6795,			-- Growl
 
-		--Paladin
-		62124, --Hand of Reckoning
+		-- Hunter
+		20736, 			-- Distracting Shot
 
-		--Druid
-		6795, --Growl
+		-- Hunter Pet
+		-- 2649, 			-- Growl
+		-- 61676, 			-- Growl
+		-- 14916, 			-- Growl
+		-- 14920, 			-- Growl
+		-- 14918, 			-- Growl
+		-- 14921, 			-- Growl
+		-- 27047, 			-- Growl
+		-- 14917, 			-- Growl
+		-- 14919, 			-- Growl
 
-		--Hunter
-		20736, --Distracting Shot
+		-- Paladin
+		62124, 			-- Hand of Reckoning
 
-		--Shaman
-		5730, --Stoneclaw Totem
+		-- Shaman
+		2062, 			-- Earth Elemental Totem
+		5730, 			-- Stoneclaw Totem
+		6390, 			-- Stoneclaw Totem
+		6391, 			-- Stoneclaw Totem
+		6392, 			-- Stoneclaw Totem
+		10427,			-- Stoneclaw Totem
+		10428,			-- Stoneclaw Totem
+		25525,			-- Stoneclaw Totem
+		58580,			-- Stoneclaw Totem
+		58581,			-- Stoneclaw Totem
+		58582,			-- Stoneclaw Totem
+
+		-- Warlock Pet
+		-- 33699, 		-- Anguish
+		-- 47993, 		-- Anguish
+		-- 33698, 		-- Anguish
+		-- 33700, 		-- Anguish
+		-- 3716, 		-- Torment
+		-- 7809, 		-- Torment
+		-- 7810, 		-- Torment
+		-- 7811, 		-- Torment
+		-- 11774, 		-- Torment
+		-- 11775, 		-- Torment
+		-- 27270, 		-- Torment
+		-- 47984, 		-- Torment
+
+		-- Warrior
+		355, 			-- Taunt
+		694, 			-- Mocking Blow
 	},
 	AOE = {
-		--Warrior
-		1161, --Challenging Shout
+		-- Death Knight
+		42650, 			-- Army of the Dead
 
-		--Paladin
-		31789, --Righteous Defense
+		-- Druid
+		5209, 			-- Challenging Roar
 
-		--Druid
-		5209, --Challenging Roar
+		-- Paladin
+		31789, 			-- Righteous Defense
 
-		--Warlock
-		59671, --Challenging Howl
+		-- Warlock
+		59671, 			-- Challenging Howl
+
+		-- Warlock Pet
+		-- 17735, 		-- Suffering
+		-- 17750, 		-- Suffering
+		-- 17751, 		-- Suffering
+		-- 17752, 		-- Suffering
+		-- 27271, 		-- Suffering
+		-- 33701, 		-- Suffering
+		-- 47989, 		-- Suffering
+		-- 47990, 		-- Suffering
+
+		-- Warrior
+		1161, 		-- Challenging Shout
 	},
 };


### PR DESCRIPTION
Added all the ranks of Shaman Stoneclaw Totem & Earth Elemental Totem, as well as Army of the Dead for DKs.

Added pets, but commented them out.